### PR TITLE
dependabot bump ver

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -37,7 +37,7 @@ jobs:
         python-version: '3.13'
         
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update astral-sh/setup-uv GitHub Action from v4 to v7 in the build-binaries workflow