### PR TITLE
Base PR to add new module, Issue #60 

### DIFF
--- a/src/vba_edit/cli_common.py
+++ b/src/vba_edit/cli_common.py
@@ -16,11 +16,48 @@ try:
     import tomllib as toml_lib  # Python 3.11+ includes tomllib in stdlib
 except ImportError:
     try:
-        import tomli as toml_lib  # tomli is the recommended TOML parser for Python <3.11
+        import tomli as toml_lib  # tomli is the recommended TOML parser for Python <3.11 # type: ignore[import-not-found]
     except ImportError:
-        import toml as toml_lib  # Fall back to toml package if tomli isn't available
+        import toml as toml_lib  # Fall back to toml package if tomli isn't available # type: ignore[import-not-found]
 
 logger = logging.getLogger(__name__)
+
+
+# region PRcompat
+# for PR integration only, until test modules are updated
+def add_folder_organization_arguments(parser: argparse.ArgumentParser) -> None:
+    add_vba_files_arguments(parser)
+    add_exporting_arguments(parser)
+
+def add_export_arguments(parser: argparse.ArgumentParser) -> None:
+    add_exporting_arguments(parser)
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    add_config_arguments(parser)
+    add_command_arguments(parser)
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        dest=CONFIG_KEY_VERBOSE,
+        action="store_true",
+        help="Enable verbose logging output",
+    )
+
+
+PLACEHOLDER_FILE_NAME_LEGACY = "{general.file.name}"
+PLACEHOLDER_FILE_FULLNAME_LEGACY = "{general.file.fullname}"
+PLACEHOLDER_FILE_PATH_LEGACY = "{general.file.path}"
+PLACEHOLDER_VBA_PROJECT_LEGACY = "{vbaproject}"
+PLACEHOLDER_VBA_PROJECT = PLACEHOLDER_VBA_PROJECT_LEGACY
+
+def _placeholder_compatibility_stub(placeholders: Dict[str, str]) -> Dict[str, str]:
+    placeholders[PLACEHOLDER_FILE_NAME_LEGACY] = placeholders[PLACEHOLDER_FILE_NAME]
+    placeholders[PLACEHOLDER_FILE_FULLNAME_LEGACY] = placeholders[PLACEHOLDER_FILE_FULLNAME]
+    placeholders[PLACEHOLDER_FILE_PATH_LEGACY] = placeholders[PLACEHOLDER_FILE_PATH]
+    placeholders[PLACEHOLDER_VBA_PROJECT] = placeholders[PLACEHOLDER_FILE_VBAPROJECT]
+    placeholders[PLACEHOLDER_VBA_PROJECT_LEGACY] = placeholders[PLACEHOLDER_FILE_VBAPROJECT]
+    return placeholders
+# endregion
 
 
 def handle_export_with_warnings(
@@ -87,21 +124,6 @@ def handle_export_with_warnings(
             handler.export_vba(save_metadata=save_metadata, overwrite=True, interactive=False, keep_open=keep_open)
 
 
-# Placeholder constants for configuration file substitution
-# New simplified format (v0.4.1+)
-PLACEHOLDER_CONFIG_PATH = "{config.path}"
-PLACEHOLDER_FILE_NAME = "{file.name}"
-PLACEHOLDER_FILE_FULLNAME = "{file.fullname}"
-PLACEHOLDER_FILE_PATH = "{file.path}"
-PLACEHOLDER_FILE_VBAPROJECT = "{file.vbaproject}"
-# Legacy placeholders for backward compatibility (deprecated in v0.4.1, will be removed in v0.5.0)
-PLACEHOLDER_FILE_NAME_LEGACY = "{general.file.name}"
-PLACEHOLDER_FILE_FULLNAME_LEGACY = "{general.file.fullname}"
-PLACEHOLDER_FILE_PATH_LEGACY = "{general.file.path}"
-PLACEHOLDER_VBA_PROJECT_LEGACY = "{vbaproject}"
-# Aliases for test compatibility (deprecated, use new names above)
-PLACEHOLDER_VBA_PROJECT = PLACEHOLDER_VBA_PROJECT_LEGACY  # For backward compatibility in tests
-
 # TOML configuration section constants
 CONFIG_SECTION_GENERAL = "general"
 CONFIG_SECTION_OFFICE = "office"
@@ -111,19 +133,94 @@ CONFIG_SECTION_ACCESS = "access"
 CONFIG_SECTION_POWERPOINT = "powerpoint"
 CONFIG_SECTION_ADVANCED = "advanced"
 
-# TOML configuration key constants (for general section)
+# TOML configuration keys (general section) and argument namespace attributes
 CONFIG_KEY_FILE = "file"
 CONFIG_KEY_VBA_DIRECTORY = "vba_directory"
 CONFIG_KEY_PQ_DIRECTORY = "pq_directory"
 CONFIG_KEY_ENCODING = "encoding"
 CONFIG_KEY_DETECT_ENCODING = "detect_encoding"
 CONFIG_KEY_SAVE_HEADERS = "save_headers"
+CONFIG_KEY_IN_FILE_HEADERS = "in_file_headers"
+CONFIG_KEY_SAVE_METADATA = "save_metadata"
 CONFIG_KEY_VERBOSE = "verbose"
 CONFIG_KEY_LOGFILE = "logfile"
 CONFIG_KEY_RUBBERDUCK_FOLDERS = "rubberduck_folders"
 CONFIG_KEY_INVISIBLE_MODE = "invisible_mode"
-CONFIG_KEY_MODE = "mode"
 CONFIG_KEY_OPEN_FOLDER = "open_folder"
+CONFIG_KEY_FORCE_OVERWRITE = "force_overwrite"
+CONFIG_KEY_KEEP_OPEN = "keep_open"
+CONFIG_KEY_NO_COLOR = "no_color"
+CONFIG_KEY_XLWINGS = "xlwings"
+
+# Placeholder constants for use in arguments and configuration values
+PLACEHOLDER_CONFIG_PATH = "{config.path}"
+PLACEHOLDER_FILE_NAME = "{file.name}"
+PLACEHOLDER_FILE_FULLNAME = "{file.fullname}"
+PLACEHOLDER_FILE_PATH = "{file.path}"
+PLACEHOLDER_FILE_VBAPROJECT = "{file.vbaproject}"
+
+# Valid placeholders by config key (exported for other modules)
+CONFIG_KEY_PLACEHOLDERS: Dict[str, tuple[str, ...]] = {
+    CONFIG_KEY_VBA_DIRECTORY: (
+        PLACEHOLDER_FILE_NAME,
+        PLACEHOLDER_FILE_FULLNAME,
+        PLACEHOLDER_FILE_PATH,
+        PLACEHOLDER_CONFIG_PATH,
+        PLACEHOLDER_FILE_VBAPROJECT,
+    ),
+    CONFIG_KEY_LOGFILE: (
+        PLACEHOLDER_FILE_NAME,
+        PLACEHOLDER_FILE_FULLNAME,
+        PLACEHOLDER_FILE_PATH,
+        PLACEHOLDER_CONFIG_PATH,
+    ),
+}
+
+
+def get_placeholders_for_config_key(config_key: str) -> tuple[str, ...]:
+    """Return the valid placeholders for a given config key."""
+    return CONFIG_KEY_PLACEHOLDERS.get(config_key, ())
+
+
+# Office application CLI configurations
+OFFICE_CLI_CONFIGS = {
+    "excel": {
+        "entry_point": "excel-vba",
+        "app_name": "Excel",
+        "file_type": "workbook",
+        "file_extensions": "*.bas/*.cls/*.frm",
+        "example_filename": "workbook.xlsm",
+    },
+    "word": {
+        "entry_point": "word-vba",
+        "app_name": "Word",
+        "file_type": "document",
+        "file_extensions": "*.bas/*.cls/*.frm",
+        "example_filename": "document.docx",
+    },
+    "access": {
+        "entry_point": "access-vba",
+        "app_name": "MS Access",
+        "file_type": "database",
+        "file_extensions": "*.bas/*.cls",  # Access only supports modules and class modules
+        "example_filename": "database.accdb",
+    },
+    "powerpoint": {
+        "entry_point": "powerpoint-vba",
+        "app_name": "PowerPoint",
+        "file_type": "presentation",
+        "file_extensions": "*.bas/*.cls/*.frm",
+        "example_filename": "presentation.pptx",
+    },
+}
+
+# Centralized help strings
+CLI_HELP_STRINGS = {
+    "edit": "Edit VBA in external editor, sync changes back to {file_type}",
+    "import": "Import VBA from filesystem into {file_type}",
+    "export": "Export VBA from {file_type} to filesystem",
+    "check": "Check VBA project access settings in {app_name}",
+}
 
 
 def resolve_placeholders_in_value(value: str, placeholders: Dict[str, str]) -> str:
@@ -150,9 +247,6 @@ def resolve_placeholders_in_value(value: str, placeholders: Dict[str, str]) -> s
 def get_placeholder_values(config_file_path: Optional[str] = None, file_path: Optional[str] = None) -> Dict[str, str]:
     """Get placeholder values based on config file and file paths.
 
-    Supports both new simplified placeholders ({file.name}) and legacy ones ({general.file.name})
-    for backward compatibility.
-
     Args:
         config_file_path: Path to the TOML config file (optional)
         file_path: Path to the Office document (optional)
@@ -161,17 +255,11 @@ def get_placeholder_values(config_file_path: Optional[str] = None, file_path: Op
         Dictionary mapping placeholder names to their values
     """
     placeholders = {
-        # New format (v0.4.1+)
         PLACEHOLDER_CONFIG_PATH: "",
         PLACEHOLDER_FILE_NAME: "",
         PLACEHOLDER_FILE_FULLNAME: "",
         PLACEHOLDER_FILE_PATH: "",
         PLACEHOLDER_FILE_VBAPROJECT: "",  # Resolved later
-        # Legacy format (deprecated)
-        PLACEHOLDER_FILE_NAME_LEGACY: "",
-        PLACEHOLDER_FILE_FULLNAME_LEGACY: "",
-        PLACEHOLDER_FILE_PATH_LEGACY: "",
-        PLACEHOLDER_VBA_PROJECT_LEGACY: "",  # Resolved later
     }
 
     # Get config file directory for relative path resolution
@@ -194,16 +282,13 @@ def get_placeholder_values(config_file_path: Optional[str] = None, file_path: Op
             file_fullname = resolved_file_path.name  # filename with extension
             file_path_str = str(resolved_file_path.parent)
 
-            # New format
             placeholders[PLACEHOLDER_FILE_NAME] = file_name
             placeholders[PLACEHOLDER_FILE_FULLNAME] = file_fullname
             placeholders[PLACEHOLDER_FILE_PATH] = file_path_str
-            # Legacy format (same values)
-            placeholders[PLACEHOLDER_FILE_NAME_LEGACY] = file_name
-            placeholders[PLACEHOLDER_FILE_FULLNAME_LEGACY] = file_fullname
-            placeholders[PLACEHOLDER_FILE_PATH_LEGACY] = file_path_str
 
+    placeholders = _placeholder_compatibility_stub(placeholders)
     return placeholders
+
 
 
 def resolve_all_placeholders(args: argparse.Namespace, config_file_path: Optional[str] = None) -> argparse.Namespace:
@@ -220,13 +305,14 @@ def resolve_all_placeholders(args: argparse.Namespace, config_file_path: Optiona
 
     # Get file path from args for placeholder resolution
     file_path = args_dict.get("file")
-
     # Get placeholder values
+
     placeholders = get_placeholder_values(config_file_path, file_path)
 
-    # Resolve placeholders in all string arguments
+    # Resolve placeholders only in arguments that support them
+    placeholder_enabled_args = {CONFIG_KEY_VBA_DIRECTORY, CONFIG_KEY_LOGFILE}
     for key, value in args_dict.items():
-        if isinstance(value, str):
+        if key in placeholder_enabled_args and isinstance(value, str):
             args_dict[key] = resolve_placeholders_in_value(value, placeholders)
 
     # Store config file path for later VBA project placeholder resolution
@@ -234,78 +320,6 @@ def resolve_all_placeholders(args: argparse.Namespace, config_file_path: Optiona
         args_dict["_config_file_path"] = config_file_path
 
     return argparse.Namespace(**args_dict)
-
-
-def resolve_vbaproject_placeholder_in_args(args: argparse.Namespace, vba_project_name: str) -> argparse.Namespace:
-    """Resolve the {file.vbaproject} and legacy {vbaproject} placeholders after VBA project name is known.
-
-    Supports both new simplified placeholder ({file.vbaproject}) and legacy one ({vbaproject})
-    for backward compatibility.
-
-    Args:
-        args: Command-line arguments
-        vba_project_name: Name of the VBA project
-
-    Returns:
-        Arguments with vbaproject placeholders resolved
-    """
-    args_dict = vars(args).copy()
-
-    # Resolve both new and legacy placeholders in all string arguments
-    for key, value in args_dict.items():
-        if isinstance(value, str):
-            # New format
-            value = value.replace(PLACEHOLDER_FILE_VBAPROJECT, vba_project_name)
-            # Legacy format
-            value = value.replace(PLACEHOLDER_VBA_PROJECT_LEGACY, vba_project_name)
-            args_dict[key] = value
-
-    return argparse.Namespace(**args_dict)
-
-
-def resolve_config_placeholders_recursive(value, placeholders: Dict[str, str]):
-    """Recursively resolve placeholders in nested configuration structures.
-
-    Args:
-        value: Value to process (can be dict, list, or string)
-        placeholders: Dictionary mapping placeholder names to values
-
-    Returns:
-        Value with placeholders resolved
-    """
-    if isinstance(value, str):
-        return resolve_placeholders_in_value(value, placeholders)
-    elif isinstance(value, dict):
-        return {k: resolve_config_placeholders_recursive(v, placeholders) for k, v in value.items()}
-    elif isinstance(value, list):
-        return [resolve_config_placeholders_recursive(item, placeholders) for item in value]
-    else:
-        return value
-
-
-def resolve_vbaproject_placeholder(config: Dict[str, Any], vba_project_name: str) -> Dict[str, Any]:
-    """Resolve the {file.vbaproject} and legacy {vbaproject} placeholders after VBA project name is known.
-
-    Supports both new simplified placeholder ({file.vbaproject}) and legacy one ({vbaproject})
-    for backward compatibility.
-
-    Args:
-        config: Configuration dictionary
-        vba_project_name: Name of the VBA project
-
-    Returns:
-        Configuration with vbaproject placeholders resolved
-    """
-    import copy
-
-    resolved_config = copy.deepcopy(config)
-
-    placeholders = {
-        PLACEHOLDER_FILE_VBAPROJECT: vba_project_name,  # New format
-        PLACEHOLDER_VBA_PROJECT_LEGACY: vba_project_name,  # Legacy format
-    }
-
-    return resolve_config_placeholders_recursive(resolved_config, placeholders)
 
 
 def _enhance_toml_error_message(config_path: str, text: str, err: Exception) -> str:
@@ -316,7 +330,7 @@ def _enhance_toml_error_message(config_path: str, text: str, err: Exception) -> 
         base = f"{base} (at line {getattr(err, 'lineno', None)}, column {getattr(err, 'colno', None)})"
 
     # Look for suspicious backslashes in double-quoted values of known path keys
-    keys = ("file", "vba_directory", "pq_directory", "logfile")
+    keys = (CONFIG_KEY_FILE, CONFIG_KEY_VBA_DIRECTORY, CONFIG_KEY_PQ_DIRECTORY, CONFIG_KEY_LOGFILE)
     pattern = re.compile(
         r"^(\s*(?:" + "|".join(re.escape(k) for k in keys) + r')\s*=\s*)"([^"\r\n]*)"',
         re.IGNORECASE | re.MULTILINE,
@@ -438,18 +452,21 @@ def add_config_arguments(parser: argparse.ArgumentParser) -> None:
     Args:
         parser: The argument parser to add arguments to
     """
-    parser.add_argument(
+    config_group = parser.add_argument_group("Configuration")
+    config_group.add_argument(
         "--conf",
         "--config",
         metavar="CONFIG_FILE",
-        help="Path to configuration file (TOML format) with argument values. "
-        "Command-line arguments override config file values. "
-        "Configuration values support placeholders: {config.path}, {general.file.name}, {general.file.fullname}, {general.file.path}, {vbaproject}",
+        help=(
+            "Path to configuration file (TOML format)\n"
+            "Command-line arguments override config file values. "
+            "Values in the configuration file support the same placeholders as the corresponding command-line arguments."
+        ),
     )
 
 
-def add_common_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add common arguments to a parser.
+def add_command_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common command arguments to a parser.
 
     These are arguments common to edit/import/export commands.
     Global options (--version, --help) are added at the main parser level.
@@ -457,32 +474,81 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     Args:
         parser: The argument parser to add arguments to
     """
-    add_config_arguments(parser)
-    parser.add_argument(
+    # File Options group
+    file_group = parser.add_argument_group("File Options")
+    file_group.add_argument(
         "--file",
         "-f",
-        help="Path to Office document (optional, defaults to active document). "
-        "Supports placeholders: {general.file.name}, {general.file.fullname}, {general.file.path}, {vbaproject}",
+        dest=CONFIG_KEY_FILE,
+        help="Path to Office document (default: active document).",
     )
-    parser.add_argument(
+    file_group.add_argument(
         "--vba-directory",
-        help="Directory to export VBA files to (optional, defaults to current directory) "
-        "Supports placeholders: {general.file.name}, {general.file.fullname}, {general.file.path}, {vbaproject}",
+        dest=CONFIG_KEY_VBA_DIRECTORY,
+        metavar="DIR",
+        help="Directory to export VBA files to (default: same directory as document).\n"
+        f"Supports placeholders: {', '.join(get_placeholders_for_config_key(CONFIG_KEY_VBA_DIRECTORY))}",
     )
-    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging output")
-    parser.add_argument(
-        "--logfile",
-        "-l",
-        nargs="?",
-        const="vba_edit.log",
-        help="Enable logging to file. Optional path can be specified (default: vba_edit.log)"
-        "Supports placeholders: {general.file.name}, {general.file.fullname}, {general.file.path}, {vbaproject}",
-    )
-    parser.add_argument(
-        "--no-color",
-        "--no-colour",
+
+
+def add_vba_files_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add folder organization and encoding/decodingarguments to a parser.
+
+    These arguments only make sense for commands that handle VBA code
+    (edit, export, import) and should not be available globally.
+
+    Args:
+        parser: The argument parser to add arguments to
+    """
+    add_encoding_arguments(parser)
+    vba_src_file_group = parser.add_argument_group("Source File Organization")
+    vba_src_file_group.add_argument(
+        "--rubberduck-folders",
+        dest=CONFIG_KEY_RUBBERDUCK_FOLDERS,
         action="store_true",
-        help="Disable colored output (useful for CI/CD, piping, or personal preference)",
+        help="Organize folders per RubberduckVBA @Folder annotations",
+    )
+
+
+def add_exporting_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add export-specific arguments to a parser.
+
+    These arguments only make sense for commands that export VBA code
+    (edit, export) and should not be available globally.
+
+    Args:
+        parser: The argument parser to add arguments to
+    """
+    add_header_arguments(parser)
+    add_metadata_arguments(parser)
+    exporting_group = parser.add_argument_group("Export Options")
+    exporting_group.add_argument(
+        "--force-overwrite",
+        dest=CONFIG_KEY_FORCE_OVERWRITE,
+        action="store_true",
+        help="Force overwrite of existing files without prompting",
+    )
+    exporting_group.add_argument(
+        "--open-folder",
+        dest=CONFIG_KEY_OPEN_FOLDER,
+        action="store_true",
+        help="Open export directory in file explorer after export",
+    )
+
+
+def add_after_export_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add office file-specific arguments to a parser.
+
+    These arguments only make sense for the export command
+
+    Args:
+        parser: The argument parser to add arguments to
+    """
+    parser.add_argument(
+        "--keep-open",
+        dest=CONFIG_KEY_KEEP_OPEN,
+        action="store_true",
+        help="Keep document open after export (default: close after export)",
     )
 
 
@@ -505,26 +571,28 @@ def add_common_option_group(parser: argparse.ArgumentParser) -> argparse._Argume
         >>> import_parser = subparsers.add_parser("import")
         >>> add_common_option_group(import_parser)
     """
+    # Common Options group
     common_group = parser.add_argument_group("Common Options")
     common_group.add_argument(
         "--verbose",
         "-v",
-        dest="verbose",
+        dest=CONFIG_KEY_VERBOSE,
         action="store_true",
         help="Enable verbose logging output",
     )
     common_group.add_argument(
         "--logfile",
         "-l",
-        dest="logfile",
+        dest=CONFIG_KEY_LOGFILE,
         nargs="?",
         const="vba_edit.log",
-        help="Enable logging to file (default: vba_edit.log)",
+        help="Enable logging to file (default: vba_edit.log)\n"
+        f"Supports placeholders: {', '.join(get_placeholders_for_config_key(CONFIG_KEY_LOGFILE))}",
     )
     common_group.add_argument(
         "--no-color",
         "--no-colour",
-        dest="no_color",
+        dest=CONFIG_KEY_NO_COLOR,
         action="store_true",
         help="Disable colored output",
     )
@@ -534,30 +602,6 @@ def add_common_option_group(parser: argparse.ArgumentParser) -> argparse._Argume
         action="help",
         help="Show this help message and exit",
     )
-    return common_group
-
-
-def add_folder_organization_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add folder organization arguments to a parser.
-
-    These arguments only make sense for commands that export VBA code
-    (edit, export, import) and should not be available globally.
-
-    Args:
-        parser: The argument parser to add arguments to
-    """
-    parser.add_argument(
-        "--rubberduck-folders",
-        action="store_true",
-        default=False,
-        help="If a module contains a RubberduckVBA '@Folder annotation, organize folders in the file system accordingly",
-    )
-    parser.add_argument(
-        "--open-folder",
-        action="store_true",
-        default=False,
-        help="Open the export directory in file explorer after successful export",
-    )
 
 
 def add_excel_specific_arguments(parser: argparse.ArgumentParser) -> None:
@@ -566,9 +610,11 @@ def add_excel_specific_arguments(parser: argparse.ArgumentParser) -> None:
     Args:
         parser: The argument parser to add arguments to
     """
-    parser.add_argument(
+    excel_group = parser.add_argument_group("Excel-Specific Options")
+    excel_group.add_argument(
         "--xlwings",
         "-x",
+        dest=CONFIG_KEY_XLWINGS,
         action="store_true",
         help="""Use xlwings backend with vba-edit enhancements. Adds custom --vba-directory 
         support (automatically changes directory and creates it if needed). Useful for 
@@ -577,25 +623,30 @@ def add_excel_specific_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def add_encoding_arguments(parser: argparse.ArgumentParser, default_encoding: str = None) -> None:
+def add_encoding_arguments(parser: argparse.ArgumentParser) -> None:
     """Add encoding-related arguments to a parser.
 
     Args:
         parser: The argument parser to add arguments to
-        default_encoding: Default encoding to use
     """
-    if default_encoding is None:
-        default_encoding = get_windows_ansi_codepage() or "cp1252"
+    default_encoding = get_windows_ansi_codepage() or "cp1252"
 
-    encoding_group = parser.add_mutually_exclusive_group()
-    encoding_group.add_argument(
+    encoding_group = parser.add_argument_group("Encoding Options (mutually exclusive)")
+    encoding_mutex = encoding_group.add_mutually_exclusive_group()
+    encoding_mutex.add_argument(
         "--encoding",
         "-e",
-        help=f"Encoding to be used when reading/writing VBA files (e.g., 'utf-8', 'windows-1252', default: {default_encoding})",
+        dest=CONFIG_KEY_ENCODING,
+        metavar="ENCODING",
         default=default_encoding,
+        help=f"Encoding used for reading/writing VBA files (e.g. 'utf-8', 'windows-1252', default: {default_encoding})",
     )
-    encoding_group.add_argument(
-        "--detect-encoding", "-d", action="store_true", default=None, help="Auto-detect file encoding for VBA files"
+    encoding_mutex.add_argument(
+        "--detect-encoding",
+        "-d",
+        dest=CONFIG_KEY_DETECT_ENCODING,
+        action="store_true",
+        help="Auto-detect file encoding for VBA files",
     )
 
 
@@ -605,23 +656,25 @@ def add_header_arguments(parser: argparse.ArgumentParser) -> None:
     Args:
         parser: The argument parser to add arguments to
     """
-    parser.add_argument(
+    header_group = parser.add_argument_group("Header Options (mutually exclusive)")
+    header_mutex = header_group.add_mutually_exclusive_group()
+    header_mutex.add_argument(
         "--save-headers",
+        dest=CONFIG_KEY_SAVE_HEADERS,
         action="store_true",
-        default=False,
-        help="Save VBA component headers to separate .header files (default: False)",
+        help="Save VBA component headers to separate .header files",
     )
-    parser.add_argument(
+    header_mutex.add_argument(
         "--in-file-headers",
+        dest=CONFIG_KEY_IN_FILE_HEADERS,
         action="store_true",
-        default=False,
-        help="Include VBA headers directly in code files instead of separate .header files (default: False)",
+        help="Include VBA headers directly in code files",
     )
 
 
 def validate_header_options(args: argparse.Namespace) -> None:
     """Validate that header options are not conflicting."""
-    if getattr(args, "save_headers", False) and getattr(args, "in_file_headers", False):
+    if getattr(args, CONFIG_KEY_SAVE_HEADERS, False) and getattr(args, CONFIG_KEY_IN_FILE_HEADERS, False):
         raise argparse.ArgumentTypeError(
             "Options --save-headers and --in-file-headers are mutually exclusive. "
             "Choose either separate header files or embedded headers."
@@ -634,30 +687,269 @@ def add_metadata_arguments(parser: argparse.ArgumentParser) -> None:
     Args:
         parser: The argument parser to add arguments to
     """
-    parser.add_argument(
+    metadata_group = parser.add_argument_group("Metadata Options")
+    metadata_group.add_argument(
         "--save-metadata",
         "-m",
+        dest=CONFIG_KEY_SAVE_METADATA,
         action="store_true",
-        default=None,
-        help="Save metadata file with character encoding information (default: False)",
+        help="Save metadata to file",
     )
 
 
-def add_export_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add export-specific arguments to a parser.
+def get_office_config(office_app: str) -> Dict[str, str]:
+    """Get configuration for specified Office application.
 
     Args:
-        parser: The argument parser to add arguments to
+        office_app: Office application name (excel, word, access, powerpoint)
+
+    Returns:
+        Configuration dictionary
+
+    Raises:
+        KeyError: If office_app is not supported
     """
-    parser.add_argument(
-        "--force-overwrite",
-        action="store_true",
-        default=False,
-        help="Force overwrite of existing files without prompting for confirmation (use with caution)",
+    if office_app not in OFFICE_CLI_CONFIGS:
+        raise KeyError(f"Unsupported Office application: {office_app}")
+    return OFFICE_CLI_CONFIGS[office_app]
+
+
+def get_help_string(command: str, office_app: str) -> str:
+    """Get help string for a command and Office application.
+
+    Args:
+        command: Command name (edit, import, export, check)
+        office_app: Office application name
+
+    Returns:
+        Formatted help string
+    """
+    config = get_office_config(office_app)
+    template = CLI_HELP_STRINGS.get(command, f"{command.title()} VBA content")
+    return template.format(**config)
+
+
+def get_command_description(command: str, office_app: str) -> str:
+    """Get description string for a command and Office application.
+
+    Args:
+        command: Command name (edit, import, export, check)
+        office_app: Office application name
+    Returns:
+        Formatted description string
+    """
+    config = get_office_config(office_app)
+
+    match command:
+        case "import":
+            command_description = f"""Import VBA code from filesystem into {config["file_type"]}
+
+Header handling is automatic - no flags needed:
+  • Detects inline headers (VERSION/BEGIN/Attribute at file start)
+  • Falls back to separate .header files if present
+  • Creates minimal headers if neither exists
+
+Simple usage:
+  {config["entry_point"]} {command}          # Uses active {config["file_type"]} and imports from same directory
+
+Full control usage:
+  {config["entry_point"]} {command} -f {config["example_filename"]} --vba-directory src"""
+
+        case "export":
+            command_description = f"""Export VBA code from {config["file_type"]} to filesystem
+
+Simple usage:
+  {config["entry_point"]} {command}           # Uses active {config["file_type"]} and exports to same directory
+  
+Full control usage:
+  {config["entry_point"]} {command} -f {config["example_filename"]} --vba-directory src"""
+
+        case "edit":
+            command_description = f"""Export VBA code from {config["file_type"]} to filesystem, edit in external editor and sync changes back into {config["file_type"]} on save [CTRL+S]
+
+Simple usage:
+  {config["entry_point"]} {command}           # Uses active {config["file_type"]} and VBA code files are 
+                            # saved in the same location as the {config["file_type"]}
+  
+Full control usage:
+  {config["entry_point"]} {command} -f {config["example_filename"]} --vba-directory src"""
+
+        case "check":
+            command_description = f"""Check if 'Trust access to the VBA project object model' is enabled
+
+Simple usage:
+  {config["entry_point"]} {command}          # Check {config["app_name"]} VBA access
+  {config["entry_point"]} {command} all      # Check all Office applications"""
+        case _:
+            command_description = "dummy"
+
+    return command_description
+
+
+def get_command_usage(command: str, office_app: str) -> str:
+    """Get usage string for a command and Office application.
+
+    Args:
+        command: Command name (edit, import, export, check)
+        office_app: Office application name
+    Returns:
+        Formatted usage string
+    """
+    common_command_options1 = """
+    [--file FILE | -f FILE]
+    [--vba-directory DIR]"""
+
+    edit_and_export_options = """
+    [--save-headers | --in-file-headers]
+    [--save-metadata | -m]
+    [--open-folder]
+    [--force-overwrite]"""
+
+    after_export_options = """
+    [--keep-open]"""
+
+    vba_handling_options = """
+    [--encoding ENCODING | -e ENCODING | --detect-encoding | -d]
+    [--rubberduck-folders]"""
+
+    config_options = """
+    [--conf FILE | --config FILE]"""
+
+    app_excel_specific_options = """
+    [--xlwings | -x]"""
+
+    common_command_options2 = """
+    [--verbose | -v]
+    [--logfile | -l]
+    [--no-color | --no-colour]
+    [--help | -h]"""
+
+    config = get_office_config(office_app)
+
+    command_usage = f"{config['entry_point']} {command}"
+    match command:
+        case "export" | "edit" | "import":
+            command_usage = f"{command_usage}{common_command_options1}"
+
+            if command in ("edit", "export"):
+                command_usage = f"{command_usage}{edit_and_export_options}"
+
+            if command == "export":
+                command_usage = f"{command_usage}{after_export_options}"
+
+            command_usage = f"{command_usage}{vba_handling_options}"
+            if office_app == "excel":
+                command_usage = f"{command_usage}{app_excel_specific_options}"
+            command_usage = f"{command_usage}{config_options}"
+
+    command_usage = f"{command_usage}{common_command_options2}"
+
+    return command_usage
+
+
+EXAMPLE_FILENAME_MAX_LEN = 24
+EXAMPLE_COMMAND_COL_WIDTH = 46
+
+
+def _cap_example_filename(example_filename: str, max_len: int = EXAMPLE_FILENAME_MAX_LEN) -> str:
+    """Cap example filename length to keep example alignment stable."""
+    if len(example_filename) <= max_len:
+        return example_filename
+    return example_filename[: max_len - 1] + "…"
+
+
+def _format_example_line(command: str, comment: str, col_width: int = EXAMPLE_COMMAND_COL_WIDTH) -> str:
+    """Format example line with aligned comments."""
+    return f"{command.ljust(col_width)}# {comment}"
+
+
+def create_cli_description(
+    entry_point_name: str,
+    package_name_formatted: str,
+    package_version: str,
+    app_name: str,
+    file_type: str,
+    file_extensions: str,
+    example_filename: str,
+) -> str:
+    """Create standardized CLI description for Office VBA tools."""
+    return f"""{package_name_formatted} v{package_version} ({entry_point_name})
+
+A command-line tool for managing VBA content in {app_name} {file_type}s.
+Export, import, and edit VBA code in external editor with live sync back to the {file_type}."""
+
+
+def create_cli_examples(
+    entry_point_name: str,
+    package_name_formatted: str,
+    package_version: str,
+    app_name: str,
+    file_type: str,
+    file_extensions: str,
+    example_filename: str,
+) -> str:
+    """Create standardized CLI description for Office VBA tools."""
+    example_filename = _cap_example_filename(example_filename)
+
+    edit_cmd = f"{entry_point_name} edit"
+    export_cmd = f"{entry_point_name} export -f {example_filename}"
+    import_cmd = f"{entry_point_name} import --vba-directory src"
+    check_cmd = f"{entry_point_name} check"
+
+    return f"""
+Examples:
+  {_format_example_line(edit_cmd, f"Edit in external editor, sync changes to {file_type}")}
+  {_format_example_line(export_cmd, "Export VBA to directory")}
+  {_format_example_line(import_cmd, "Import VBA from directory")}
+  {_format_example_line(check_cmd, "Verify that access to VBA is enabled")}
+
+Use '{entry_point_name} <command> --help' for more information on a specific command.
+    
+IMPORTANT: Requires "Trust access to the VBA project object model" enabled in {app_name}.
+           Early release - backup important files before use!"""
+
+
+def create_office_cli_description(office_app: str, package_name_formatted: str, package_version: str) -> str:
+    """Create CLI description for specified Office application.
+
+    Args:
+        office_app: Office application name (excel, word, access, powerpoint)
+        package_name_formatted: Package name for display (e.g., "excel-vba")
+        package_version: Version string
+
+    Returns:
+        Formatted description string
+    """
+    config = get_office_config(office_app)
+    return create_cli_description(
+        entry_point_name=config["entry_point"],
+        package_name_formatted=package_name_formatted,
+        package_version=package_version,
+        app_name=config["app_name"],
+        file_type=config["file_type"],
+        file_extensions=config["file_extensions"],
+        example_filename=config["example_filename"],
     )
-    parser.add_argument(
-        "--keep-open",
-        action="store_true",
-        default=False,
-        help="Keep document open after export (default: close document after export completes)",
+
+
+def create_office_cli_examples(office_app: str, package_name_formatted: str, package_version: str) -> str:
+    """Create CLI epilog for specified Office application.
+
+    Args:
+        office_app: Office application name (excel, word, access, powerpoint)
+        package_name_formatted: Package name for display (e.g., "excel-vba")
+        package_version: Version string
+
+    Returns:
+        Formatted epilog string
+    """
+    config = get_office_config(office_app)
+    return create_cli_examples(
+        entry_point_name=config["entry_point"],
+        package_name_formatted=package_name_formatted,
+        package_version=package_version,
+        app_name=config["app_name"],
+        file_type=config["file_type"],
+        file_extensions=config["file_extensions"],
+        example_filename=config["example_filename"],
     )

--- a/src/vba_edit/office_cli.py
+++ b/src/vba_edit/office_cli.py
@@ -1,0 +1,575 @@
+"""Generic Office VBA CLI factory for creating standardized CLI interfaces.
+
+This module provides a centralized, generic CLI factory for all Office VBA command-line tools (Excel, Word, Access, PowerPoint).
+
+## Key Benefits
+- **Consistent Behavior**: All Office tools behave identically with unified error handling
+- **Easy Maintenance**: Bug fixes and new features automatically apply to all Office apps
+- **Extensibility**: Adding new Office applications requires minimal effort
+- **Clean Special Handling**: Office-specific features (xlwings, Access multi-DB) are isolated
+
+## Architecture
+
+The `OfficeVBACLI` class provides a generic implementation that can be configured for any
+Office application. Special handling for unique features is managed through:
+
+- **Hook Functions**: Pre-command processing (e.g., Access multi-database checks)
+- **Handler Functions**: Special command processing (e.g., Excel xlwings integration)
+- **Configuration**: Office-specific settings and arguments
+
+## Usage
+
+```python
+# Create simplified Office modules
+from vba_edit.office_cli import create_office_main
+
+# Word VBA module becomes just:
+main = create_office_main("word")
+
+if __name__ == "__main__":
+    main()
+```
+
+Other modules with special handling (like Excel) can still implement their unique features without affecting the overall structure or other Office applications.
+
+## Supported Office Applications
+
+- **Excel**: Full support including xlwings integration
+- **Word**: Standard VBA operations
+- **Access**: Standard operations with multi-database handling
+- **PowerPoint**: Standard VBA operations
+
+## Special Handling
+
+### Excel-Specific Features
+- xlwings wrapper integration (`--xlwings` flag)
+- Excel-specific argument handling
+
+### Access-Specific Features
+- Multi-database detection and handling
+- Database-specific warning messages
+
+### Standard Features (Word, PowerPoint)
+- No special handling required
+"""
+
+import argparse
+import logging
+
+import sys
+from pathlib import Path
+
+from vba_edit import __name__ as package_name
+from vba_edit import __version__ as package_version
+from vba_edit.cli_common import (
+    CONFIG_KEY_VBA_DIRECTORY,
+    CONFIG_SECTION_GENERAL,
+    PLACEHOLDER_FILE_VBAPROJECT,
+    add_after_export_arguments,
+    add_common_option_group,
+    add_config_arguments,
+    get_placeholders_for_config_key,
+    handle_export_with_warnings,
+    load_config_file,
+    merge_config_with_args,
+    resolve_all_placeholders,
+    validate_header_options,
+    get_command_usage,
+    get_command_description,
+    add_command_arguments,
+    add_vba_files_arguments,
+    add_exporting_arguments,
+    add_excel_specific_arguments,
+    create_office_cli_description,
+    create_office_cli_examples,
+    get_help_string,
+    get_office_config,
+)
+from vba_edit.exceptions import (
+    ApplicationError,
+    DocumentClosedError,
+    DocumentNotFoundError,
+    PathError,
+    RPCError,
+    VBAAccessError,
+    VBAError,
+)
+from vba_edit.help_formatter import ColorizedArgumentParser, EnhancedHelpFormatter
+from vba_edit.office_vba import (
+    ExcelVBAHandler,
+    WordVBAHandler,
+    AccessVBAHandler,
+    PowerPointVBAHandler,
+)
+from vba_edit.path_utils import get_document_paths
+from vba_edit.utils import get_active_office_document, setup_logging
+from vba_edit.console import error
+
+from typing import Callable, Type
+
+
+# Eager mapping (backwards-compatible; values are classes)
+OFFICE_HANDLERS: dict[str, Type] = {
+    "excel": ExcelVBAHandler,
+    "word": WordVBAHandler,
+    "access": AccessVBAHandler,
+    "powerpoint": PowerPointVBAHandler,
+}
+
+# Lazy mapping of Office applications to their handler *factories*
+# NOTE: Factories are used so tests can patch vba_edit.office_cli.ExcelVBAHandler
+# and have it take effect without needing to patch a pre-built dict.
+OFFICE_HANDLER_FACTORIES: dict[str, Callable[[], Type]] = {
+    "excel": lambda: ExcelVBAHandler,
+    "word": lambda: WordVBAHandler,
+    "access": lambda: AccessVBAHandler,
+    "powerpoint": lambda: PowerPointVBAHandler,
+}
+
+# Configure module logger
+logger = logging.getLogger(__name__)
+
+
+def _get_office_function(office_app: str, function_name: str):
+    """Dynamically import and return an office-specific function.
+
+    Args:
+        office_app: Office application name (excel, word, access, powerpoint)
+        function_name: Name of the function to import
+
+    Returns:
+        The requested function, or None if not found
+    """
+    try:
+        if office_app == "excel":
+            from vba_edit import excel_vba
+
+            return getattr(excel_vba, function_name, None)
+        elif office_app == "word":
+            from vba_edit import word_vba
+
+            return getattr(word_vba, function_name, None)
+        elif office_app == "access":
+            from vba_edit import access_vba
+
+            return getattr(access_vba, function_name, None)
+        elif office_app == "powerpoint":
+            from vba_edit import powerpoint_vba
+
+            return getattr(powerpoint_vba, function_name, None)
+    except (ImportError, AttributeError):
+        return None
+
+    return None
+
+
+# Office-specific configuration with dynamic function names
+OFFICE_SPECIAL_HANDLING = {
+    "access": {
+        "pre_command_hook": "access_pre_command_hook",
+        "extra_notes": ["NOTE: The database will remain open - close it manually when finished."],
+    },
+    "excel": {"xlwings_handler": "excel_xlwings_handler", "extra_arguments": add_excel_specific_arguments},
+    "word": {},
+    "powerpoint": {},
+}
+
+
+class OfficeVBACLI:
+    """Generic Office VBA CLI that can be configured for any Office application."""
+
+    def __init__(self, office_app: str):
+        """Initialize CLI for specific Office application.
+
+        Args:
+            office_app: Office application name (excel, word, access, powerpoint)
+        """
+        self.office_app = office_app
+        self.config = get_office_config(office_app)
+
+        # Store a factory, not the class
+        self._handler_factory = OFFICE_HANDLER_FACTORIES[office_app]
+
+        self.special_config = OFFICE_SPECIAL_HANDLING.get(office_app, {})
+        self.logger = logging.getLogger(f"{__name__}.{office_app}")
+
+    def _get_special_function(self, function_key: str):
+        """Get a special function for this office app."""
+        function_name = self.special_config.get(function_key)
+        if isinstance(function_name, str):
+            return _get_office_function(self.office_app, function_name)
+        return function_name
+
+    def _collect_parser_dests(self, parser: argparse.ArgumentParser) -> set:
+        dests = set()
+        for action in parser._actions:
+            if action.dest and action.dest is not argparse.SUPPRESS:
+                dests.add(action.dest)
+            if isinstance(action, argparse._SubParsersAction):
+                for subparser in action.choices.values():
+                    dests.update(self._collect_parser_dests(subparser))
+        return dests
+
+    def _get_subparser(self, parser: argparse.ArgumentParser, command: str) -> argparse.ArgumentParser | None:
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                return action.choices.get(command)
+        return None
+
+    def _get_config_defaults(self, parser: argparse.ArgumentParser, config: dict) -> dict:
+        defaults = {}
+        general_config = config.get(CONFIG_SECTION_GENERAL, {})
+        if not isinstance(general_config, dict):
+            return defaults
+
+        known_dests = self._collect_parser_dests(parser)
+        for key, value in general_config.items():
+            arg_key = key.replace("-", "_")
+            if arg_key in known_dests:
+                defaults[arg_key] = value
+
+        return defaults
+
+    def create_cli_parser(self) -> argparse.ArgumentParser:
+        """Create the command-line interface parser."""
+        entry_point_name = self.config["entry_point"]
+        package_name_formatted = package_name.replace("_", "-")
+
+        # Create streamlined main help description
+        main_description = create_office_cli_description(self.office_app, package_name_formatted, package_version)
+
+        # Create streamlined examples for main help
+        main_examples = create_office_cli_examples(self.office_app, package_name_formatted, package_version)
+
+        parser = ColorizedArgumentParser(
+            prog=entry_point_name,
+            usage=f"{entry_point_name} [--help] [--version] <command> [<args>]",
+            description=main_description,
+            epilog=main_examples,
+            formatter_class=EnhancedHelpFormatter,
+        )
+
+        # Add --version argument to the main parser
+        parser.add_argument(
+            "--version",
+            "-V",
+            action="version",
+            version=f"{package_name_formatted} v{package_version} ({entry_point_name})",
+        )
+
+        # Add hidden easter egg flags (not shown in help)
+        parser.add_argument("--diagram", action="store_true", help=argparse.SUPPRESS)
+        parser.add_argument("--how-it-works", action="store_true", help=argparse.SUPPRESS)
+
+        subparsers = parser.add_subparsers(
+            dest="command",
+            required=True,
+            title="Commands",
+            metavar="<command>",
+        )
+
+        # Import command
+        import_parser = subparsers.add_parser(
+            "import",
+            usage=get_command_usage("import", self.office_app),
+            help=get_help_string("import", self.office_app),
+            description=get_command_description("import", self.office_app),
+            formatter_class=EnhancedHelpFormatter,
+            add_help=False,
+        )
+        add_command_arguments(import_parser)
+        add_vba_files_arguments(import_parser)
+        add_config_arguments(import_parser)  # Add config file options to import command
+        add_common_option_group(import_parser)  # Add common options to import command
+
+        # Export command
+        export_parser = subparsers.add_parser(
+            "export",
+            usage=get_command_usage("export", self.office_app),
+            help=get_help_string("export", self.office_app),
+            description=get_command_description("export", self.office_app),
+            formatter_class=EnhancedHelpFormatter,
+            add_help=False,
+        )
+        add_command_arguments(export_parser)
+        add_exporting_arguments(export_parser)
+        add_after_export_arguments(export_parser)
+        add_vba_files_arguments(export_parser)
+        add_config_arguments(export_parser)  # Add config file options to export command
+        add_common_option_group(export_parser)  # Add common options to export command
+
+        # Edit command
+        edit_parser = subparsers.add_parser(
+            "edit",
+            usage=get_command_usage("edit", self.office_app),
+            help=get_help_string("edit", self.office_app),
+            description=get_command_description("edit", self.office_app),
+            formatter_class=EnhancedHelpFormatter,
+            add_help=False,  # Suppress default help to add it manually in Common Options
+        )
+        add_command_arguments(edit_parser)
+        add_exporting_arguments(edit_parser)
+        add_vba_files_arguments(edit_parser)
+        add_config_arguments(edit_parser)  # Add config file options to edit command
+        add_common_option_group(edit_parser)  # Add common options to edit command
+
+        # Check command
+        check_parser = subparsers.add_parser(
+            "check",
+            usage=get_command_usage("check", self.office_app),
+            help=get_help_string("check", self.office_app),
+            description=get_command_description("check", self.office_app),
+            formatter_class=EnhancedHelpFormatter,
+            add_help=False,
+        )
+        add_common_option_group(check_parser)  # Add common options to check command
+
+        # Add application specific arguments
+        extra_args_func = self._get_special_function("extra_arguments")
+        if extra_args_func:
+            extra_args_func(edit_parser)
+            extra_args_func(import_parser)
+            extra_args_func(export_parser)
+
+        return parser
+
+    def validate_paths(self, args: argparse.Namespace) -> None:
+        """Validate file and directory paths from command line arguments.
+
+        Only validates paths for commands that actually use them (edit, import, export).
+        The 'check' command doesn't use file/vba_directory arguments.
+        """
+        # Skip validation for commands that don't use file paths
+        if args.command == "check":
+            return
+
+        if args.file and not Path(args.file).exists():
+            file_type = self.config["file_type"]
+            raise FileNotFoundError(f"{file_type.title()} not found: {args.file}")
+
+        if args.vba_directory:
+            # Only create the VBA directory if there's no PLACEHOLDER_FILE_VBAPROJECT value, or if it is already resolved
+            if PLACEHOLDER_FILE_VBAPROJECT not in args.vba_directory:
+                vba_dir = Path(args.vba_directory)
+                if not vba_dir.exists():
+                    self.logger.info(f"Creating VBA directory: {vba_dir}")
+                    vba_dir.mkdir(parents=True, exist_ok=True)
+
+    def handle_office_vba_command(self, args: argparse.Namespace) -> None:
+        """Handle the office-vba command execution."""
+        try:
+            # Initialize logging
+            setup_logging(verbose=getattr(args, "verbose", False), logfile=getattr(args, "logfile", None))
+            self.logger.debug(f"Starting {self.office_app}-vba command: {args.command}")
+            self.logger.debug(f"Command arguments: {vars(args)}")
+
+            # Ensure paths exist early (creates vba_directory if provided)
+            self.validate_paths(args)
+
+            # Run application-specific pre-command hook
+            pre_hook = self._get_special_function("pre_command_hook")
+            if pre_hook:
+                pre_hook(args)
+
+            # Handle xlwings option if present (Excel only)
+            xlwings_handler = self._get_special_function("xlwings_handler")
+            if xlwings_handler and xlwings_handler(self, args):
+                return  # xlwings handled the command
+
+            # Get document path and active document path
+            active_file = None
+            if not args.file:
+                try:
+                    active_file = get_active_office_document(self.office_app)
+                except ApplicationError:
+                    pass
+
+            try:
+                file_path, vba_dir = get_document_paths(
+                    args.file,
+                    active_file,
+                    args.vba_directory,
+                    get_placeholders_for_config_key(CONFIG_KEY_VBA_DIRECTORY),
+                )
+                file_type = self.config["file_type"]
+                self.logger.info(f"Using {file_type}: {file_path}")
+                self.logger.debug(f"Using VBA directory: {vba_dir}")
+            except (DocumentNotFoundError, PathError) as e:
+                self.logger.error(f"Failed to resolve paths: {str(e)}")
+                sys.exit(1)
+
+            # Determine encoding
+            encoding = None if getattr(args, "detect_encoding", False) else args.encoding
+            self.logger.debug(f"Using encoding: {encoding or 'auto-detect'}")
+
+            # Validate header options
+            validate_header_options(args)
+
+            # Create handler instance
+            try:
+                handler_class = self._handler_factory()
+                handler = handler_class(
+                    doc_path=str(file_path),
+                    vba_dir=str(vba_dir),
+                    encoding=encoding,
+                    verbose=getattr(args, "verbose", False),
+                    save_headers=getattr(args, "save_headers", False),
+                    use_rubberduck_folders=getattr(args, "rubberduck_folders", False),
+                    open_folder=getattr(args, "open_folder", False),
+                    in_file_headers=getattr(args, "in_file_headers", True),
+                )
+            except VBAError as e:
+                app_name = self.config["app_name"]
+                self.logger.error(f"Failed to initialize {app_name} VBA handler: {str(e)}")
+                sys.exit(1)
+
+            # Execute requested command
+            self.logger.info(f"Executing command: {args.command}")
+            try:
+                if args.command == "edit":
+                    print("NOTE: Deleting a VBA module file will also delete it in the VBA editor!")
+
+                    # Add office-specific notes
+                    extra_notes = self.special_config.get("extra_notes", [])
+                    for note in extra_notes:
+                        print(note)
+
+                    handler.export_vba(overwrite=False)
+                    try:
+                        handler.watch_changes()
+                    except (DocumentClosedError, RPCError) as e:
+                        self.logger.error(str(e))
+                        app_name = self.config["app_name"]
+                        self.logger.info(
+                            f"Edit session terminated. Please restart {app_name} and this tool to continue editing."
+                        )
+                        sys.exit(1)
+                elif args.command == "import":
+                    handler.import_vba()
+                elif args.command == "export":
+                    handle_export_with_warnings(
+                        handler,
+                        save_metadata=getattr(args, "save_metadata", False),
+                        overwrite=True,
+                        interactive=True,
+                        force_overwrite=getattr(args, "force_overwrite", False),
+                        keep_open=getattr(args, "keep_open", False),
+                    )
+            except (DocumentClosedError, RPCError) as e:
+                self.logger.error(str(e))
+                sys.exit(1)
+            except VBAAccessError as e:
+                self.logger.error(str(e))
+                app_name = self.config["app_name"]
+                self.logger.error(f"Please check {app_name} Trust Center Settings and try again.")
+                sys.exit(1)
+            except VBAError as e:
+                self.logger.error(f"VBA operation failed: {str(e)}")
+                sys.exit(1)
+            except Exception as e:
+                self.logger.error(f"Unexpected error: {str(e)}")
+                if getattr(args, "verbose", False):
+                    self.logger.exception("Detailed error information:")
+                sys.exit(1)
+
+        except KeyboardInterrupt:
+            self.logger.info("\nOperation interrupted by user")
+            sys.exit(0)
+        except Exception as e:
+            self.logger.error(f"Critical error: {str(e)}")
+            if getattr(args, "verbose", False):
+                self.logger.exception("Detailed error information:")
+            sys.exit(1)
+        finally:
+            self.logger.debug("Command execution completed")
+
+    def main(self) -> None:
+        """Main entry point for the Office VBA CLI."""
+        try:
+            # Check for --no-color flag BEFORE creating parser
+            # This ensures help messages honor the flag
+            if "--no-color" in sys.argv or "--no-colour" in sys.argv:
+                from vba_edit.console import disable_colors
+
+                disable_colors()
+
+            # Handle easter egg flags first (before argparse validation)
+            # This allows them to work without requiring a command
+            if "--diagram" in sys.argv or "--how-it-works" in sys.argv:
+                from vba_edit.utils import show_workflow_diagram
+
+                show_workflow_diagram()
+
+            parser = self.create_cli_parser()
+            pre_args, _ = parser.parse_known_args()
+            config = None
+            config_load_failed = False
+            command = getattr(pre_args, "command", None)
+            config_path = getattr(pre_args, "conf", None)
+            if command in {"edit", "import", "export"} and config_path:
+                try:
+                    config = load_config_file(config_path)
+                except Exception as e:
+                    error(f"Error loading configuration file: {e}")
+                    config_load_failed = True
+                else:
+                    subparser = self._get_subparser(parser, command)
+                    target_parser = subparser or parser
+                    config_defaults = self._get_config_defaults(target_parser, config)
+                    if config_defaults:
+                        target_parser.set_defaults(**config_defaults)
+
+            args = parser.parse_args()
+
+            # Apply configuration and resolve placeholders BEFORE setting up logging
+            if not config_load_failed:
+                if config and getattr(args, "conf", None):
+                    args = merge_config_with_args(args, config)
+                    args = resolve_all_placeholders(args, args.conf)
+                else:
+                    args = resolve_all_placeholders(args, None)
+
+            # Set up logging first
+            setup_logging(verbose=getattr(args, "verbose", False), logfile=getattr(args, "logfile", None))
+
+            # Create target directories and validate inputs early
+            self.validate_paths(args)
+
+            # Run 'check' command (Check if VBA project model is accessible)
+            if args.command == "check":
+                from vba_edit.utils import check_vba_trust_access
+
+                try:
+                    if getattr(args, "subcommand", None) == "all":
+                        check_vba_trust_access()  # Check all supported Office applications
+                    else:
+                        check_vba_trust_access(self.office_app)  # Check specific Office app only
+                except Exception as e:
+                    self.logger.error(f"Failed to check Trust Access to VBA project object model: {str(e)}")
+                sys.exit(0)
+            else:
+                self.handle_office_vba_command(args)
+
+        except Exception as e:
+            from vba_edit.console import print_exception
+
+            # Use print_exception to properly render Rich markup in exception messages
+            print_exception(e)
+            sys.exit(1)
+
+
+def create_office_main(office_app: str):
+    """Create a main function for a specific Office application.
+
+    Args:
+        office_app: Office application name (excel, word, access, powerpoint)
+
+    Returns:
+        Main function for the Office application
+    """
+
+    def main():
+        cli = OfficeVBACLI(office_app)
+        cli.main()
+
+    return main

--- a/src/vba_edit/office_vba.py
+++ b/src/vba_edit/office_vba.py
@@ -37,6 +37,12 @@ from vba_edit.utils import (
 )
 from vba_edit.console import console
 
+from vba_edit.cli_common import (
+    get_placeholders_for_config_key,
+    CONFIG_KEY_VBA_DIRECTORY,
+    PLACEHOLDER_FILE_VBAPROJECT,
+)
+
 
 def _filter_attributes(code: str) -> str:
     """Filter out hidden member-level Attribute lines from the given code.
@@ -839,7 +845,9 @@ class OfficeVBAHandler(ABC):
         """Initialize the VBA handler."""
         try:
             # Let DocumentNotFoundError propagate as is - it's more fundamental than VBA errors
-            self.doc_path, self.vba_dir = get_document_paths(doc_path, None, vba_dir)
+            self.doc_path, self.vba_dir = get_document_paths(
+                doc_path, None, vba_dir, get_placeholders_for_config_key(CONFIG_KEY_VBA_DIRECTORY)
+            )
             self.encoding = encoding
             self.verbose = verbose
             self.save_headers = save_headers
@@ -884,6 +892,17 @@ class OfficeVBAHandler(ABC):
         """Get the document type string for error messages."""
         return "workbook" if self.app_name == "Excel" else "document"
 
+    def _resolve_vbaproject_placeholder(self, vba_project_name: str) -> None:
+        """Resolve {vbaproject} placeholder in vba_dir after VBA project name is known."""
+        vba_dir_str = str(self.vba_dir)
+        if PLACEHOLDER_FILE_VBAPROJECT in vba_dir_str:
+            resolved_path = vba_dir_str.replace(PLACEHOLDER_FILE_VBAPROJECT, vba_project_name)
+            self.vba_dir = Path(resolved_path)
+            logger.debug(f"Resolved {PLACEHOLDER_FILE_VBAPROJECT} placeholder in vba_dir: {self.vba_dir}")
+            if not self.vba_dir.exists():
+                logger.info(f"Creating VBA directory: {self.vba_dir}")
+                self.vba_dir.mkdir(parents=True, exist_ok=True)
+
     def get_vba_project(self) -> Any:
         """Get VBA project based on application type."""
         logger.debug("Getting VBA project...")
@@ -920,6 +939,7 @@ class OfficeVBAHandler(ABC):
                 )
 
             logger.debug("VBA project accessed successfully")
+            self._resolve_vbaproject_placeholder(vba_project.Name)
             return vba_project
 
         except Exception as e:

--- a/src/vba_edit/path_utils.py
+++ b/src/vba_edit/path_utils.py
@@ -115,7 +115,10 @@ def validate_document_path(doc_path: Optional[str], must_exist: bool = True) -> 
 
 
 def get_document_paths(
-    doc_path: Optional[str], active_doc_path: Optional[str], vba_dir: Optional[str] = None
+    doc_path: Optional[str],
+    active_doc_path: Optional[str],
+    vba_dir: Optional[str] = None,
+    vbadir_placeholders: Optional[Tuple[str, ...]] = None,
 ) -> Tuple[Path, Path]:
     """Get validated document and VBA directory paths.
 
@@ -125,15 +128,19 @@ def get_document_paths(
         doc_path: Explicit document path from CLI/API
         active_doc_path: Path from active Office document
         vba_dir: Optional VBA directory override
-
+        vbadir_placeholders: Optional tuple of placeholders for VBA directory
     Returns:
         Tuple of (document_path, vba_directory_path)
 
     Raises:
         DocumentNotFoundError: If no valid document path can be found
         PathError: If VBA directory path is invalid
+        TypeError: If vbadir_placeholders is not a tuple
     """
     logger.debug(f"get_document_paths: doc_path={doc_path}, active_doc_path={active_doc_path}, vba_dir={vba_dir}")
+
+    if vbadir_placeholders is not None and not isinstance(vbadir_placeholders, tuple):
+        raise TypeError("vbadir_placeholders must be a tuple of placeholder strings, or None")
 
     # Try explicit path first
     try:
@@ -162,8 +169,16 @@ def get_document_paths(
 
     # Ensure VBA directory exists
     try:
-        vba_path.mkdir(parents=True, exist_ok=True)
-        logger.debug(f"get_document_paths: ensured VBA directory exists: {vba_path}")
+        # Only create the VBA directory if the path does not contain any known placeholder token, or if they are already resolved
+        vba_path_text = str(vba_path)
+        placeholder_tokens = vbadir_placeholders or ()
+        contains_placeholder = any(token and token in vba_path_text for token in placeholder_tokens)
+
+        if not contains_placeholder:
+            vba_path.mkdir(parents=True, exist_ok=True)
+            logger.debug(f"get_document_paths: ensured VBA directory exists: {vba_path}")
+        else:
+            logger.debug(f"get_document_paths: skipped mkdir; unresolved placeholders in path: {vba_path_text}")
     except Exception as e:
         logger.exception("get_document_paths: failed to create/access VBA directory")
         raise PathError(f"Failed to create/access VBA directory: {e}")


### PR DESCRIPTION
includes fixes for placeholder handling and new module office_cli.py for unified CLI handling, but does not yet switch the app specific modules to it.

## Summary by Sourcery

Introduce a generic Office VBA CLI framework and refine placeholder handling and configuration for CLI arguments and paths.

New Features:
- Add a centralized office_cli module and OfficeVBACLI factory to provide a unified, extensible CLI for Excel, Word, Access, and PowerPoint VBA tools.
- Expose office-specific CLI configuration, shared help text, and usage/description/example generators for all Office applications.

Bug Fixes:
- Ensure VBA directory creation is skipped when unresolved placeholder tokens are present, preventing invalid directory paths.
- Correct and centralize handling of legacy and new placeholders, including {file.vbaproject}, across argument resolution and VBA handlers.

Enhancements:
- Restructure CLI argument groups for better organization, consistent dest keys, and clearer help text, including placeholder-aware options.
- Limit placeholder resolution to supported arguments and export valid placeholder sets per config key for reuse in other modules.
- Add Excel-specific and application-specific hooks into the new CLI while preserving backward compatibility through compatibility helpers and factories.

Documentation:
- Add detailed module-level documentation and in-line descriptions explaining the architecture and usage of the new office_cli CLI factory.