### PR TITLE
refactor: excel_vba to use unified CLI handler

### DIFF
--- a/src/vba_edit/excel_vba.py
+++ b/src/vba_edit/excel_vba.py
@@ -1,753 +1,61 @@
 import argparse
-import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
 
-from vba_edit import __name__ as package_name
-from vba_edit import __version__ as package_version
-from vba_edit.cli_common import (
-    handle_export_with_warnings,
-    process_config_file,
-    validate_header_options,
-)
-from vba_edit.exceptions import (
-    ApplicationError,
-    DocumentClosedError,
-    DocumentNotFoundError,
-    PathError,
-    RPCError,
-    VBAAccessError,
-    VBAError,
-)
-from vba_edit.help_formatter import (
-    ColorizedArgumentParser,
-    EnhancedHelpFormatter,
-)
-from vba_edit.office_vba import ExcelVBAHandler
-from vba_edit.path_utils import get_document_paths
-from vba_edit.utils import get_active_office_document, get_windows_ansi_codepage, setup_logging
+from vba_edit.office_cli import create_office_main
 
-# Configure module logger
-logger = logging.getLogger(__name__)
+# region PRcompat
+# for PR integration only, until test modules are updated
+from vba_edit.office_cli import OfficeVBACLI
+
+# Re-export symbols that older tests patch at vba_edit.excel_vba.*.
+# NOTE: OfficeVBACLI uses the implementations imported in vba_edit.office_cli, so we
+# also "sync" these re-exports back into that module at runtime to make patching work.
+import vba_edit.office_cli as office_cli
+from vba_edit.cli_common import handle_export_with_warnings as handle_export_with_warnings
+from vba_edit.office_vba import ExcelVBAHandler as ExcelVBAHandler
+from vba_edit.path_utils import get_document_paths as get_document_paths
+from vba_edit.utils import setup_logging as setup_logging
 
 
-def create_cli_parser() -> argparse.ArgumentParser:
-    """Create the command-line interface parser."""
-    entry_point_name = "excel-vba"
-    package_name_formatted = package_name.replace("_", "-")
+# endregion
+# region PRcompat
+MODULE_NAME = "excel"
 
-    # Get system default encoding
-    default_encoding = get_windows_ansi_codepage() or "cp1252"
 
-    # Create streamlined main help description
-    main_description = f"""{package_name_formatted} v{package_version} ({entry_point_name})
+def _sync_prcompat_patches_to_office_cli() -> None:
+    """Ensure patches applied to vba_edit.excel_vba.* affect vba_edit.office_cli.* too."""
+    office_cli.setup_logging = setup_logging
+    office_cli.get_document_paths = get_document_paths
+    office_cli.handle_export_with_warnings = handle_export_with_warnings
+    office_cli.ExcelVBAHandler = ExcelVBAHandler
 
-A command-line tool for managing VBA content in Excel workbooks.
-Export, import, and edit VBA code in external editor with live sync back to workbook."""
 
-    # Create streamlined examples for main help
-    main_examples = f"""
-Examples:
-  {entry_point_name} edit                           # Edit in external editor, sync changes to workbook
-  {entry_point_name} export -f file.xlsm            # Export VBA to directory
-  {entry_point_name} import --vba-directory src     # Import VBA from directory
-  {entry_point_name} check                          # Verify VBA access is enabled
-
-Use '{entry_point_name} <command> --help' for more information on a specific command.
-
-IMPORTANT: Requires "Trust access to VBA project object model" enabled in Excel.
-           Early release - backup important files before use!"""
-
-    parser = ColorizedArgumentParser(
-        prog=entry_point_name,
-        usage=f"{entry_point_name} [--help] [--version] <command> [<args>]",
-        description=main_description,
-        epilog=main_examples,
-        formatter_class=EnhancedHelpFormatter,
-    )
-
-    # Add --version argument to the main parser
-    parser.add_argument(
-        "--version", "-V", action="version", version=f"{package_name_formatted} v{package_version} ({entry_point_name})"
-    )
-
-    # Add hidden easter egg flags (not shown in help)
-    parser.add_argument("--diagram", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--how-it-works", action="store_true", help=argparse.SUPPRESS)
-
-    subparsers = parser.add_subparsers(
-        dest="command",
-        required=True,
-        title="Commands",
-        metavar="<command>",
-    )
-
-    # Edit command
-    edit_description = """Export VBA code from Office document to filesystem, edit VBA code files in external editor and sync changes back into Office document on save [CTRL+S]
-
-Simple usage:
-  excel-vba edit            # Uses active document and VBA code files are 
-                            # saved in the same location as the document
-  
-Full control usage:
-  excel-vba edit -f file.xlsm --vba-directory src"""
-
-    edit_usage = """excel-vba edit
-    [--file FILE | -f FILE]
-    [--vba-directory DIR]
-    [--open-folder]
-    [--conf FILE | --config FILE]
-    [--encoding ENCODING | -e ENCODING | --detect-encoding | -d]
-    [--save-headers | --in-file-headers]
-    [--save-metadata | -m]
-    [--rubberduck-folders]
-    [--xlwings | -x]
-    [--verbose | -v]
-    [--logfile | -l]
-    [--no-color | --no-colour]
-    [--help | -h]"""
-
-    edit_parser = subparsers.add_parser(
-        "edit",
-        usage=edit_usage,
-        help="Edit in external editor, sync changes back to workbook",
-        description=edit_description,
-        formatter_class=EnhancedHelpFormatter,
-        add_help=False,  # Suppress default help to add it manually in Common Options
-    )
-
-    # File Options group
-    file_group = edit_parser.add_argument_group("File Options")
-    file_group.add_argument(
-        "--file",
-        "-f",
-        dest="file",
-        help="Path to Office document (default: active document)",
-    )
-    file_group.add_argument(
-        "--vba-directory",
-        dest="vba_directory",
-        metavar="DIR",
-        help="Directory to export VBA files (default: same directory as document)",
-    )
-    file_group.add_argument(
-        "--open-folder",
-        dest="open_folder",
-        action="store_true",
-        help="Open export directory in file explorer after export",
-    )
-
-    # Configuration group
-    config_group = edit_parser.add_argument_group("Configuration")
-    config_group.add_argument(
-        "--conf",
-        "--config",
-        metavar="FILE",
-        help="Path to configuration file (TOML format)",
-    )
-
-    # Encoding Options group (mutually exclusive)
-    encoding_group = edit_parser.add_argument_group("Encoding Options (mutually exclusive)")
-    encoding_mutex = encoding_group.add_mutually_exclusive_group()
-    encoding_mutex.add_argument(
-        "--encoding",
-        "-e",
-        dest="encoding",
-        metavar="ENCODING",
-        default=default_encoding,
-        help=f"Encoding for writing VBA files (default: {default_encoding})",
-    )
-    encoding_mutex.add_argument(
-        "--detect-encoding",
-        "-d",
-        dest="detect_encoding",
-        action="store_true",
-        help="Auto-detect file encoding for VBA files",
-    )
-
-    # Header Options group (mutually exclusive)
-    header_group = edit_parser.add_argument_group("Header Options (mutually exclusive)")
-    header_mutex = header_group.add_mutually_exclusive_group()
-    header_mutex.add_argument(
-        "--save-headers",
-        dest="save_headers",
-        action="store_true",
-        help="Save VBA component headers to separate .header files",
-    )
-    header_mutex.add_argument(
-        "--in-file-headers",
-        dest="in_file_headers",
-        action="store_true",
-        help="Include VBA headers directly in code files",
-    )
-
-    # Edit Options group
-    edit_options_group = edit_parser.add_argument_group("Edit Options")
-    edit_options_group.add_argument(
-        "--save-metadata",
-        "-m",
-        dest="save_metadata",
-        action="store_true",
-        help="Save metadata to file",
-    )
-    edit_options_group.add_argument(
-        "--rubberduck-folders",
-        dest="rubberduck_folders",
-        action="store_true",
-        help="Organize folders per RubberduckVBA @Folder annotations",
-    )
-
-    # Excel-Specific Options group
-    excel_group = edit_parser.add_argument_group("Excel-Specific Options")
-    excel_group.add_argument(
-        "--xlwings",
-        "-x",
-        dest="xlwings",
-        action="store_true",
-        help="Use wrapper for xlwings vba commands",
-    )
-
-    # Common Options group
-    common_group = edit_parser.add_argument_group("Common Options")
-    common_group.add_argument(
-        "--verbose",
-        "-v",
-        dest="verbose",
-        action="store_true",
-        help="Enable verbose logging output",
-    )
-    common_group.add_argument(
-        "--logfile",
-        "-l",
-        dest="logfile",
-        nargs="?",
-        const="vba_edit.log",
-        help="Enable logging to file (default: vba_edit.log)",
-    )
-    common_group.add_argument(
-        "--no-color",
-        "--no-colour",
-        dest="no_color",
-        action="store_true",
-        help="Disable colored output",
-    )
-    common_group.add_argument(
-        "--help",
-        "-h",
-        action="help",
-        help="Show this help message and exit",
-    )
-
-    # Import command
-    import_description = """Import VBA code from filesystem into Office document
-
-Header handling is automatic - no flags needed:
-  • Detects inline headers (VERSION/BEGIN/Attribute at file start)
-  • Falls back to separate .header files if present
-  • Creates minimal headers if neither exists
-
-Simple usage:
-  excel-vba import          # Uses active document and imports from same directory
-
-Full control usage:
-  excel-vba import -f file.xlsm --vba-directory src"""
-
-    import_usage = """excel-vba import
-    [--file FILE | -f FILE]
-    [--vba-directory DIR]
-    [--conf FILE | --config FILE]
-    [--encoding ENCODING | -e ENCODING | --detect-encoding | -d]
-    [--rubberduck-folders]
-    [--xlwings | -x]
-    [--verbose | -v]
-    [--logfile | -l]
-    [--no-color | --no-colour]
-    [--help | -h]"""
-
-    import_parser = subparsers.add_parser(
-        "import",
-        usage=import_usage,
-        help="Import VBA from filesystem into workbook",
-        description=import_description,
-        formatter_class=EnhancedHelpFormatter,
-        add_help=False,
-    )
-
-    # File Options group
-    file_group = import_parser.add_argument_group("File Options")
-    file_group.add_argument(
-        "--file",
-        "-f",
-        dest="file",
-        help="Path to Office document (default: active document)",
-    )
-    file_group.add_argument(
-        "--vba-directory",
-        dest="vba_directory",
-        metavar="DIR",
-        help="Directory to import VBA files from (default: same directory as document)",
-    )
-
-    # Configuration group
-    config_group = import_parser.add_argument_group("Configuration")
-    config_group.add_argument(
-        "--conf",
-        "--config",
-        metavar="FILE",
-        help="Path to configuration file (TOML format)",
-    )
-
-    # Encoding Options group (mutually exclusive)
-    encoding_group = import_parser.add_argument_group("Encoding Options (mutually exclusive)")
-    encoding_mutex = encoding_group.add_mutually_exclusive_group()
-    encoding_mutex.add_argument(
-        "--encoding",
-        "-e",
-        dest="encoding",
-        metavar="ENCODING",
-        default=default_encoding,
-        help=f"Encoding for reading VBA files (default: {default_encoding})",
-    )
-    encoding_mutex.add_argument(
-        "--detect-encoding",
-        "-d",
-        dest="detect_encoding",
-        action="store_true",
-        help="Auto-detect file encoding for VBA files",
-    )
-
-    # Import Options group
-    import_options_group = import_parser.add_argument_group("Import Options")
-    import_options_group.add_argument(
-        "--rubberduck-folders",
-        dest="rubberduck_folders",
-        action="store_true",
-        help="Organize folders per RubberduckVBA @Folder annotations",
-    )
-
-    # Excel-Specific Options group
-    excel_group = import_parser.add_argument_group("Excel-Specific Options")
-    excel_group.add_argument(
-        "--xlwings",
-        "-x",
-        dest="xlwings",
-        action="store_true",
-        help="Use wrapper for xlwings vba commands",
-    )
-
-    # Common Options group
-    common_group = import_parser.add_argument_group("Common Options")
-    common_group.add_argument(
-        "--verbose",
-        "-v",
-        dest="verbose",
-        action="store_true",
-        help="Enable verbose logging output",
-    )
-    common_group.add_argument(
-        "--logfile",
-        "-l",
-        dest="logfile",
-        nargs="?",
-        const="vba_edit.log",
-        help="Enable logging to file (default: vba_edit.log)",
-    )
-    common_group.add_argument(
-        "--no-color",
-        "--no-colour",
-        dest="no_color",
-        action="store_true",
-        help="Disable colored output",
-    )
-    common_group.add_argument(
-        "--help",
-        "-h",
-        action="help",
-        help="Show this help message and exit",
-    )
-
-    # Export command
-    export_description = """Export VBA code from Office document to filesystem
-
-Simple usage:
-  excel-vba export          # Uses active document and exports to same directory
-  
-Full control usage:
-  excel-vba export -f file.xlsm --vba-directory src"""
-
-    export_usage = """excel-vba export
-    [--file FILE | -f FILE]
-    [--keep-open]
-    [--vba-directory DIR]
-    [--open-folder]
-    [--conf FILE | --config FILE]
-    [--encoding ENCODING | -e ENCODING | --detect-encoding | -d]
-    [--save-headers | --in-file-headers]
-    [--save-metadata | -m]
-    [--force-overwrite]
-    [--rubberduck-folders]
-    [--xlwings | -x]
-    [--verbose | -v]
-    [--logfile | -l]
-    [--no-color | --no-colour]
-    [--help | -h]"""
-
-    export_parser = subparsers.add_parser(
-        "export",
-        usage=export_usage,
-        help="Export VBA from workbook to filesystem",
-        description=export_description,
-        formatter_class=EnhancedHelpFormatter,
-        add_help=False,
-    )
-
-    # File Options group
-    file_group = export_parser.add_argument_group("File Options")
-    file_group.add_argument(
-        "--file",
-        "-f",
-        dest="file",
-        help="Path to Office document (default: active document)",
-    )
-    file_group.add_argument(
-        "--vba-directory",
-        dest="vba_directory",
-        metavar="DIR",
-        help="Directory to export VBA files (default: same directory as document)",
-    )
-    file_group.add_argument(
-        "--open-folder",
-        dest="open_folder",
-        action="store_true",
-        help="Open export directory in file explorer after export",
-    )
-
-    # Configuration group
-    config_group = export_parser.add_argument_group("Configuration")
-    config_group.add_argument(
-        "--conf",
-        "--config",
-        metavar="FILE",
-        help="Path to configuration file (TOML format)",
-    )
-
-    # Encoding Options group (mutually exclusive)
-    encoding_group = export_parser.add_argument_group("Encoding Options (mutually exclusive)")
-    encoding_mutex = encoding_group.add_mutually_exclusive_group()
-    encoding_mutex.add_argument(
-        "--encoding",
-        "-e",
-        dest="encoding",
-        metavar="ENCODING",
-        default=default_encoding,
-        help=f"Encoding for writing VBA files (default: {default_encoding})",
-    )
-    encoding_mutex.add_argument(
-        "--detect-encoding",
-        "-d",
-        dest="detect_encoding",
-        action="store_true",
-        help="Auto-detect file encoding for VBA files",
-    )
-
-    # Header Options group (mutually exclusive)
-    header_group = export_parser.add_argument_group("Header Options (mutually exclusive)")
-    header_mutex = header_group.add_mutually_exclusive_group()
-    header_mutex.add_argument(
-        "--save-headers",
-        dest="save_headers",
-        action="store_true",
-        help="Save VBA component headers to separate .header files",
-    )
-    header_mutex.add_argument(
-        "--in-file-headers",
-        dest="in_file_headers",
-        action="store_true",
-        help="Include VBA headers directly in code files",
-    )
-
-    # Export Options group
-    export_options_group = export_parser.add_argument_group("Export Options")
-    export_options_group.add_argument(
-        "--save-metadata",
-        "-m",
-        dest="save_metadata",
-        action="store_true",
-        help="Save metadata to file",
-    )
-    export_options_group.add_argument(
-        "--force-overwrite",
-        dest="force_overwrite",
-        action="store_true",
-        help="Force overwrite of existing files without prompting",
-    )
-    export_options_group.add_argument(
-        "--keep-open",
-        dest="keep_open",
-        action="store_true",
-        help="Keep document open after export (default: close after export)",
-    )
-    export_options_group.add_argument(
-        "--rubberduck-folders",
-        dest="rubberduck_folders",
-        action="store_true",
-        help="Organize folders per RubberduckVBA @Folder annotations",
-    )
-
-    # Excel-Specific Options group
-    excel_group = export_parser.add_argument_group("Excel-Specific Options")
-    excel_group.add_argument(
-        "--xlwings",
-        "-x",
-        dest="xlwings",
-        action="store_true",
-        help="Use wrapper for xlwings vba commands",
-    )
-
-    # Common Options group
-    common_group = export_parser.add_argument_group("Common Options")
-    common_group.add_argument(
-        "--verbose",
-        "-v",
-        dest="verbose",
-        action="store_true",
-        help="Enable verbose logging output",
-    )
-    common_group.add_argument(
-        "--logfile",
-        "-l",
-        dest="logfile",
-        nargs="?",
-        const="vba_edit.log",
-        help="Enable logging to file (default: vba_edit.log)",
-    )
-    common_group.add_argument(
-        "--no-color",
-        "--no-colour",
-        dest="no_color",
-        action="store_true",
-        help="Disable colored output",
-    )
-    common_group.add_argument(
-        "--help",
-        "-h",
-        action="help",
-        help="Show this help message and exit",
-    )
-
-    # Check command
-    check_description = """Check if 'Trust access to the VBA project object model' is enabled
-
-Simple usage:
-  excel-vba check           # Check Excel VBA access
-  excel-vba check all       # Check all Office applications"""
-
-    check_usage = """excel-vba check
-    [--verbose | -v]
-    [--logfile | -l]
-    [--no-color | --no-colour]
-    [--help | -h]"""
-
-    check_parser = subparsers.add_parser(
-        "check",
-        usage=check_usage,
-        help="Check VBA project access settings",
-        description=check_description,
-        formatter_class=EnhancedHelpFormatter,
-        add_help=False,
-    )
-
-    # Common Options group
-    common_group = check_parser.add_argument_group("Common Options")
-    common_group.add_argument(
-        "--verbose",
-        "-v",
-        dest="verbose",
-        action="store_true",
-        help="Enable verbose logging output",
-    )
-    common_group.add_argument(
-        "--logfile",
-        "-l",
-        dest="logfile",
-        nargs="?",
-        const="vba_edit.log",
-        help="Enable logging to file (default: vba_edit.log)",
-    )
-    common_group.add_argument(
-        "--no-color",
-        "--no-colour",
-        dest="no_color",
-        action="store_true",
-        help="Disable colored output",
-    )
-    common_group.add_argument(
-        "--help",
-        "-h",
-        action="help",
-        help="Show this help message and exit",
-    )
-
-    # Subcommand for checking all applications
-    # Note: Using custom usage above, so subparser metavar doesn't affect main help
-    check_subparser = check_parser.add_subparsers(
-        dest="subcommand",
-        required=False,
-        title="Subcommands",
-        metavar="",  # Empty metavar to avoid space in usage line
-    )
-    check_all_parser = check_subparser.add_parser(
-        "all",
-        help="Check Trust Access to VBA project model of all supported Office applications",
-        formatter_class=EnhancedHelpFormatter,
-        add_help=False,
-    )
-
-    # Common Options group for 'check all' subcommand
-    check_all_common = check_all_parser.add_argument_group("Common Options")
-    check_all_common.add_argument(
-        "--verbose",
-        "-v",
-        dest="verbose",
-        action="store_true",
-        help="Enable verbose logging output",
-    )
-    check_all_common.add_argument(
-        "--logfile",
-        "-l",
-        dest="logfile",
-        nargs="?",
-        const="vba_edit.log",
-        help="Enable logging to file (default: vba_edit.log)",
-    )
-    check_all_common.add_argument(
-        "--help",
-        "-h",
-        action="help",
-        help="Show this help message and exit",
-    )
-
-    return parser
+def validate_paths(args: argparse.Namespace) -> None:
+    """Backwards-compatible wrapper for path validation."""
+    _sync_prcompat_patches_to_office_cli()
+    OfficeVBACLI(MODULE_NAME).validate_paths(args)
 
 
 def handle_excel_vba_command(args: argparse.Namespace) -> None:
-    """Handle the excel-vba command execution."""
-    try:
-        # Initialize logging
-        setup_logging(verbose=getattr(args, "verbose", False), logfile=getattr(args, "logfile", None))
-        logger.debug(f"Starting excel-vba command: {args.command}")
-        logger.debug(f"Command arguments: {vars(args)}")
+    """Backwards-compatible wrapper for command handling."""
+    _sync_prcompat_patches_to_office_cli()
+    OfficeVBACLI(MODULE_NAME).handle_office_vba_command(args)
 
-        # Ensure paths exist early (creates vba_directory if provided)
-        validate_paths(args)
 
-        # Handle xlwings option if present
-        if getattr(args, "xlwings", False):
-            try:
-                import xlwings
+def create_cli_parser() -> argparse.ArgumentParser:
+    """Backwards-compatible wrapper.
 
-                logger.info(f"Using xlwings {xlwings.__version__}")
-                handle_xlwings_command(args)
-                return
-            except ImportError:
-                sys.exit("xlwings is not installed. Please install it with: pip install xlwings")
+    NOTE: The CLI is now centralized in OfficeVBACLI (office_cli.py). This function
+    remains to preserve the historical excel_vba module API and entry-point tests.
+    """
+    _sync_prcompat_patches_to_office_cli()
+    return OfficeVBACLI(MODULE_NAME).create_cli_parser()
 
-        # Get document path and active document path
-        active_doc = None
-        if not args.file:
-            try:
-                active_doc = get_active_office_document("excel")
-            except ApplicationError:
-                pass
 
-        try:
-            doc_path, vba_dir = get_document_paths(args.file, active_doc, args.vba_directory)
-            logger.info(f"Using workbook: {doc_path}")
-            logger.debug(f"Using VBA directory: {vba_dir}")
-        except (DocumentNotFoundError, PathError) as e:
-            logger.error(f"Failed to resolve paths: {str(e)}")
-            sys.exit(1)
-
-        # Determine encoding
-        encoding = None if getattr(args, "detect_encoding", False) else args.encoding
-        logger.debug(f"Using encoding: {encoding or 'auto-detect'}")
-
-        # Validate header options
-        validate_header_options(args)
-
-        # Create handler instance
-        try:
-            handler = ExcelVBAHandler(
-                doc_path=str(doc_path),
-                vba_dir=str(vba_dir),
-                encoding=encoding,
-                verbose=getattr(args, "verbose", False),
-                save_headers=getattr(args, "save_headers", False),
-                use_rubberduck_folders=getattr(args, "rubberduck_folders", False),
-                open_folder=getattr(args, "open_folder", False),
-                in_file_headers=getattr(args, "in_file_headers", True),
-            )
-        except VBAError as e:
-            logger.error(f"Failed to initialize Excel VBA handler: {str(e)}")
-            sys.exit(1)
-
-        # Execute requested command
-        logger.info(f"Executing command: {args.command}")
-        try:
-            if args.command == "edit":
-                logger.info("NOTE: Deleting a VBA module file will also delete it in the VBA editor!")
-                handle_export_with_warnings(
-                    handler,
-                    save_metadata=getattr(args, "save_metadata", False),
-                    overwrite=False,
-                    interactive=True,
-                    keep_open=True,  # CRITICAL: Must keep document open for edit mode
-                )
-                try:
-                    handler.watch_changes()
-                except (DocumentClosedError, RPCError) as e:
-                    logger.error(str(e))
-                    logger.info("Edit session terminated. Please restart Excel and the tool to continue editing.")
-                    sys.exit(1)
-            elif args.command == "import":
-                handler.import_vba()
-            elif args.command == "export":
-                handle_export_with_warnings(
-                    handler,
-                    save_metadata=getattr(args, "save_metadata", False),
-                    overwrite=True,
-                    interactive=True,
-                    force_overwrite=getattr(args, "force_overwrite", False),
-                    keep_open=getattr(args, "keep_open", False),
-                )
-        except (DocumentClosedError, RPCError) as e:
-            logger.error(str(e))
-            sys.exit(1)
-        except VBAAccessError as e:
-            logger.error(str(e))
-            logger.error("Please check Excel Trust Center Settings and try again.")
-            sys.exit(1)
-        except VBAError as e:
-            logger.error(f"VBA operation failed: {str(e)}")
-            sys.exit(1)
-        except Exception as e:
-            logger.error(f"Unexpected error: {str(e)}")
-            if getattr(args, "verbose", False):
-                logger.exception("Detailed error information:")
-            sys.exit(1)
-
-    except KeyboardInterrupt:
-        logger.info("\nOperation interrupted by user")
-        sys.exit(0)
-    except Exception as e:
-        logger.error(f"Critical error: {str(e)}")
-        if getattr(args, "verbose", False):
-            logger.exception("Detailed error information:")
-        sys.exit(1)
-    finally:
-        logger.debug("Command execution completed")
+# endregion
 
 
 def handle_xlwings_command(args):
@@ -784,79 +92,21 @@ def handle_xlwings_command(args):
             os.chdir(original_dir)
 
 
-def validate_paths(args: argparse.Namespace) -> None:
-    """Validate file and directory paths from command line arguments.
+# If xlwings option is used, check dependency before proceeding
+def excel_xlwings_handler(cli_instance, args: argparse.Namespace) -> bool:
+    """Handle Excel xlwings functionality. Returns True if handled, False otherwise."""
+    if not getattr(args, "xlwings", False):
+        return False
 
-    Only validates paths for commands that actually use them (edit, import, export).
-    The 'check' command doesn't use file/vba_directory arguments.
-    """
-    # Skip validation for commands that don't use file paths
-    if args.command == "check":
-        return
-
-    if hasattr(args, "file") and args.file and not Path(args.file).exists():
-        raise FileNotFoundError(f"File not found: {args.file}")
-
-    if hasattr(args, "vba_directory") and args.vba_directory:
-        vba_dir = Path(args.vba_directory)
-        if not vba_dir.exists():
-            logger.info(f"Creating VBA directory: {vba_dir}")
-            vba_dir.mkdir(parents=True, exist_ok=True)
-
-
-def main() -> None:
-    """Main entry point for the excel-vba CLI."""
     try:
-        # Check for --no-color flag BEFORE creating parser
-        # This ensures help messages honor the flag
-        if "--no-color" in sys.argv or "--no-colour" in sys.argv:
-            from vba_edit.console import disable_colors
+        import xlwings  # type: ignore[import-not-found]
 
-            disable_colors()
+        cli_instance.logger.info(f"Using xlwings {xlwings.__version__}")
+        handle_xlwings_command(args)
+        return True
 
-        # Handle easter egg flags first (before argparse validation)
-        # This allows them to work without requiring a command
-        if "--diagram" in sys.argv or "--how-it-works" in sys.argv:
-            from vba_edit.utils import show_workflow_diagram
-
-            show_workflow_diagram()
-
-        parser = create_cli_parser()
-        args = parser.parse_args()
-
-        # Process configuration file BEFORE setting up logging
-        args = process_config_file(args)
-
-        # Set up logging first
-        setup_logging(verbose=getattr(args, "verbose", False), logfile=getattr(args, "logfile", None))
-
-        # Create target directories and validate inputs early
-        validate_paths(args)
-
-        # Run 'check' command (Check if VBA project model is accessible )
-        if args.command == "check":
-            from vba_edit.utils import check_vba_trust_access
-
-            try:
-                if args.subcommand == "all":
-                    check_vba_trust_access()  # Check all supported Office applications
-                else:
-                    check_vba_trust_access("excel")  # Check MS Excel only
-            except Exception as e:
-                logger.error(f"Failed to check Trust Access to VBA project object model: {str(e)}")
-            sys.exit(0)
-
-        # If xlwings option is used, check dependency before proceeding
-        elif getattr(args, "xlwings", False):
-            try:
-                import xlwings
-
-                logger.info(f"Using xlwings {xlwings.__version__}")
-                handle_xlwings_command(args)
-            except ImportError:
-                sys.exit("xlwings is not installed. Please install it with: pip install xlwings")
-        else:
-            handle_excel_vba_command(args)
+    except ImportError:
+        sys.exit("xlwings is not installed. Please install it with: pip install xlwings")
 
     except Exception as e:
         from vba_edit.console import print_exception
@@ -865,6 +115,9 @@ def main() -> None:
         print_exception(e)
         sys.exit(1)
 
+
+# Create the main function for Excel
+main = create_office_main("excel")
 
 if __name__ == "__main__":
     main()

--- a/src/vba_edit/office_cli.py
+++ b/src/vba_edit/office_cli.py
@@ -355,6 +355,32 @@ class OfficeVBACLI:
                     self.logger.info(f"Creating VBA directory: {vba_dir}")
                     vba_dir.mkdir(parents=True, exist_ok=True)
 
+    def _call_handle_export_with_warnings(
+        self,
+        handler,
+        args,
+        *,
+        overwrite: bool,
+        interactive: bool,
+        keep_open: bool = False,
+        save_metadata: bool | None = None,
+        force_overwrite: bool | None = None,
+    ) -> None:
+        """Call the module-level handle_export_with_warnings via runtime lookup.
+
+        NOTE: This indirection ensures test patches applied to vba_edit.excel_vba.handle_export_with_warnings
+        (and then synced into this module) are honored at call time.
+        """
+        module = sys.modules[__name__]
+        module.handle_export_with_warnings(
+            handler,
+            save_metadata=getattr(args, "save_metadata", False) if save_metadata is None else save_metadata,
+            overwrite=overwrite,
+            interactive=interactive,
+            force_overwrite=getattr(args, "force_overwrite", False) if force_overwrite is None else force_overwrite,
+            keep_open=keep_open,
+        )
+
     def handle_office_vba_command(self, args: argparse.Namespace) -> None:
         """Handle the office-vba command execution."""
         try:
@@ -433,8 +459,16 @@ class OfficeVBACLI:
                     extra_notes = self.special_config.get("extra_notes", [])
                     for note in extra_notes:
                         print(note)
-
-                    handler.export_vba(overwrite=False)
+                    # region Indirection to ensure test patches to handle_export_with_warnings are honored
+                    # once test_excel_vba_cli.py::test_save_metadata_passed_to_handler_edit is adapted, this can be simplified to a direct call to handle_export_with_warnings
+                    self._call_handle_export_with_warnings(
+                        handler,
+                        args,
+                        overwrite=False,
+                        interactive=True,
+                        keep_open=True,  # CRITICAL: Must keep document open for edit mode
+                    )
+                    # endregion
                     try:
                         handler.watch_changes()
                     except (DocumentClosedError, RPCError) as e:


### PR DESCRIPTION
also fixes office_cli for edit command

## Summary by Sourcery

Refactor the Excel VBA CLI to delegate to the centralized OfficeVBACLI implementation while preserving backward compatibility and existing test integrations.

Bug Fixes:
- Correct the office CLI edit command to run exports via the shared export-with-warnings flow, keeping the workbook open and honoring metadata and overwrite options as intended.

Enhancements:
- Replace the legacy excel_vba command implementation with thin wrappers around OfficeVBACLI and create_office_main for a unified Office CLI entry point.
- Introduce runtime indirection and synchronization hooks so patches to excel_vba helpers (such as handle_export_with_warnings and path utilities) are reflected in office_cli, maintaining existing test and monkeypatch behavior.