### PR TITLE
fix: add subcommand 'check all' to office_cli.py

### DIFF
--- a/src/vba_edit/office_cli.py
+++ b/src/vba_edit/office_cli.py
@@ -324,6 +324,22 @@ class OfficeVBACLI:
         )
         add_common_option_group(check_parser)  # Add common options to check command
 
+        # Subcommand for checking all applications
+        # Note: Using custom usage above, so subparser metavar doesn't affect main help
+        check_subparser = check_parser.add_subparsers(
+            dest="subcommand",
+            required=False,
+            title="Subcommands",
+            metavar="",  # Empty metavar to avoid space in usage line
+        )
+        check_all_parser = check_subparser.add_parser(
+            "all",
+            help="Check Trust Access to VBA project model of all supported Office applications",
+            formatter_class=EnhancedHelpFormatter,
+            add_help=False,
+        )
+        add_common_option_group(check_all_parser)  # Add common options to check all subcommand
+
         # Add application specific arguments
         extra_args_func = self._get_special_function("extra_arguments")
         if extra_args_func:


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a 'check all' subcommand under the check command to validate settings across all supported Office applications.