### PR TITLE
fix: use correct help text

### DIFF
--- a/src/vba_edit/cli_common.py
+++ b/src/vba_edit/cli_common.py
@@ -491,8 +491,10 @@ def add_command_arguments(parser: argparse.ArgumentParser) -> None:
         "--vba-directory",
         dest=CONFIG_KEY_VBA_DIRECTORY,
         metavar="DIR",
-        help="Directory to export VBA files to (default: same directory as document).\n"
-        f"Supports placeholders: {', '.join(get_placeholders_for_config_key(CONFIG_KEY_VBA_DIRECTORY))}",
+        help=("Directory to import VBA files from (default: same directory as document).\n"
+              if parser.prog.endswith("import") else
+              "Directory to export VBA files to (default: same directory as document).\n")
+        + f"Supports placeholders: {', '.join(get_placeholders_for_config_key(CONFIG_KEY_VBA_DIRECTORY))}",
     )
 
 


### PR DESCRIPTION
...  for --vba-directory in import vs export commands

## Summary by Sourcery

Bug Fixes:
- Correct the --vba-directory help description to reference importing when used with the import subcommand.