### PR TITLE
Fix issue #83: skip .frx copy when source and target are the same file.

### DIFF
--- a/src/vba_edit/office_vba.py
+++ b/src/vba_edit/office_vba.py
@@ -1715,6 +1715,10 @@ class OfficeVBAHandler(ABC):
             frx_source = resolve_path(f"{name}.frx", self.vba_dir)
             if frx_source.exists():
                 frx_target = resolve_path(f"{name}.frx", Path(self.doc.FullName).parent)
+                # Skip copy when source and target are the same file (vba_dir == workbook dir)
+                if frx_source.resolve() == frx_target.resolve():
+                    logger.debug(f"Skipping form binary copy for {name}.frx: source and target are the same file")
+                    return
                 try:
                     # If target exists and is read-only, make it writable temporarily
                     if frx_target.exists():
@@ -1732,7 +1736,7 @@ class OfficeVBAHandler(ABC):
                     raise VBAError(f"Failed to import form binary {name}.frx") from e
         except PathError as e:
             raise VBAError(f"Failed to handle form binary path: {str(e)}") from e
-
+        
     @abstractmethod
     def _update_document_module(self, name: str, code: str, components: Any) -> None:
         """Update an existing document module."""


### PR DESCRIPTION
Reproduction: excel-vba import, with an excel file containing UserForm(s), and located in the same folder as excel-vba.exe itself

Error Message: Failed to copy from binary *.frx: [WinError 32]
Cause: Excel locks these files when open, causing the copy to fail

Fix: added check and avoiding copy with the following lines
                if frx_source.resolve() == frx_target.resolve():
                    logger.debug(f"Skipping form binary copy for {name}.frx: source and target are the same file")
                    return

## Summary by Sourcery

Bug Fixes:
- Prevent failures when importing UserForms from workbooks located in the same directory as the executable by skipping redundant .frx file copies.